### PR TITLE
Check nan

### DIFF
--- a/custom_physics.lua
+++ b/custom_physics.lua
@@ -76,9 +76,9 @@ function pa28.physics(self)
 
     if new_velocity then
         new_velocity = vector.add(new_velocity, vector.multiply(self._last_accell, self.dtime))
-        if new_velocity.x == nil then new_velocity.x = 0 end
-        if new_velocity.y == nil then new_velocity.y = 0 end
-        if new_velocity.z == nil then new_velocity.z = 0 end        
+        if new_velocity.x == nil or minetest.is_nan(new_velocity.x) then new_velocity.x = 0 end
+        if new_velocity.y == nil or minetest.is_nan(new_velocity.y) then new_velocity.y = 0 end
+        if new_velocity.z == nil or minetest.is_nan(new_velocity.z) then new_velocity.z = 0 end        
 
         --[[
         new_velocity correction


### PR DESCRIPTION
The pa28 is crashing velocity with user kyro on mercurio server, i recommend check nan

Logs:

```
2022-11-02 22:45:41: WARNING[Main]: ServerEnv: Trying to store id = 0 statically but block (-17,3,120) already contains 256 objects.
2022-11-02 22:45:41: WARNING[Main]: ServerEnv: Trying to store id = 0 statically but block (-17,3,120) already contains 256 objects.
2022-11-02 22:45:41: WARNING[Main]: ServerEnv: Trying to store id = 0 statically but block (-17,3,120) already contains 256 objects.
2022-11-02 22:45:41: WARNING[Main]: ServerEnv: Trying to store id = 0 statically but block (-17,3,120) already contains 256 objects.
2022-11-02 22:45:43: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'pa28' in callback luaentity_Step(): Invalid float value for 'x' (NaN or infinity)
2022-11-02 22:45:43: ERROR[Main]: stack traceback:
2022-11-02 22:45:43: ERROR[Main]:     [C]: in function 'set_velocity'
2022-11-02 22:45:43: ERROR[Main]:     /usr/share/minetest/mods/pa28/custom_physics.lua:106: in function 'physics'
2022-11-02 22:45:43: ERROR[Main]:     /usr/share/minetest/mods/pa28/entities.lua:316: in function 'func'
2022-11-02 22:45:43: ERROR[Main]:     /usr/share/minetest/builtin/profiler/instrumentation.lua:107: in function </usr/share/minetest/builtin/profiler/instrumentation.lua:100>
```