### PR TITLE
Make lights blinking and change color of tail light (white)

### DIFF
--- a/entities.lua
+++ b/entities.lua
@@ -42,7 +42,7 @@ minetest.register_entity('pa28:p_lights',{
 	    visual = "mesh",
 	    mesh = "pa28_lights.b3d",
         textures = {
-                        "pa28_l_light.png", --luz posicao
+                        "pa28_white.png", --luz posicao
                         "pa28_l_light.png", --luz posicao esq
                         "pa28_r_light.png", --luz posicao dir
             },

--- a/init.lua
+++ b/init.lua
@@ -55,9 +55,12 @@ end
 function pa28.step_additional_function(self)
     --position lights
     if self._engine_running == true then
-        self.lights:set_properties({textures={"pa28_l_light.png^pa28_l_light.png","pa28_l_light.png","pa28_r_light.png"},glow=15})
+        local current_glow = self.lights:get_properties().glow
+        minetest.after(1, function()
+        self.lights:set_properties({textures={"pa28_white.png^pa28_white.png","pa28_l_light.png","pa28_r_light.png"},glow=15-current_glow})
+        end)
     else
-        self.lights:set_properties({textures={"pa28_l_light.png","pa28_l_light.png","pa28_r_light.png"},glow=0})
+        self.lights:set_properties({textures={"pa28_white.png","pa28_l_light.png","pa28_r_light.png"},glow=0})
     end
 
     if self._land_light == true then


### PR DESCRIPTION
As the title say, it turns the tail light into white (the default color on irl planes), and make them blinking with a basic `minetest.after()` function. I used the already existing `pa28_white.png` texture.